### PR TITLE
Extended Room class to include metadata Map.

### DIFF
--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -14,6 +14,7 @@ class Room {
     this.name,
     required this.type,
     required this.users,
+    this.metadata,
   });
 
   /// Room's unique ID
@@ -32,4 +33,7 @@ class Room {
 
   /// List of users which are in the room
   final List<User> users;
+
+  /// Additional custom metadata or attributes related to the room
+  final Map<String, dynamic>? metadata;
 }


### PR DESCRIPTION
### Context

This `flutter_firebase_chat_core` dependency is a great start on implementing chat, but the current room concept can be quite basic and cannot be extended upon easily without forking and diverging away from the core implementation to suit a specific use-case.

This introduces a Map to the `Room` object, called `metadata`, which allows the user to add additional metadata to the room that allows wider usage of the `flutter_firebase_chat_core` without forking it for specific needs.
