### PR TITLE
Fix: Custom message `copyWith`

### DIFF
--- a/lib/src/messages/custom_message.dart
+++ b/lib/src/messages/custom_message.dart
@@ -90,7 +90,7 @@ class CustomMessage extends Message {
       createdAt: createdAt,
       id: id,
       metadata: metadata == null
-          ? null
+          ? this.metadata
           : {
               ...this.metadata ?? {},
               ...metadata,


### PR DESCRIPTION
Copy with method will override original metadata with a null value