### PR TITLE
feat: allow overriding author and createdAt

### DIFF
--- a/lib/src/message.dart
+++ b/lib/src/message.dart
@@ -54,15 +54,17 @@ abstract class Message extends Equatable {
   /// Creates a copy of the message with an updated data
   /// [metadata] with null value will nullify existing metadata, otherwise
   /// both metadatas will be merged into one Map, where keys from a passed
-  /// metadata will overwite keys from the previous one.
+  /// metadata will overwrite keys from the previous one.
   /// [previewData] will be only set for the text message type.
   /// [remoteId], [showStatus] and [updatedAt] with null values will nullify existing value.
-  /// [status] with null value will be overwritten by the previous status.
+  /// [author], [createdAt] and [status] with null value will be overwritten by the previous status.
   /// [text] will be only set for the text message type. Null value will be
   /// overwritten by the previous text (can't be empty).
   /// [uri] will be only set for file and image message types. Null value
   /// will be overwritten by the previous value (uri can't be empty).
   Message copyWith({
+    User? author,
+    int? createdAt,
     Map<String, dynamic>? metadata,
     PreviewData? previewData,
     String? remoteId,

--- a/lib/src/messages/custom_message.dart
+++ b/lib/src/messages/custom_message.dart
@@ -80,11 +80,13 @@ class CustomMessage extends Message {
   /// metadata will overwite keys from the previous one.
   /// [previewData] is ignored for this message type.
   /// [remoteId], [showStatus] and [updatedAt] with null values will nullify existing value.
-  /// [status] with null value will be overwritten by the previous status.
+  /// [author], [createdAt] and [status] with null value will be overwritten by the previous status.
   /// [text] is ignored for this message type.
   /// [uri] is ignored for this message type.
   @override
   Message copyWith({
+    User? author,
+    int? createdAt,
     Map<String, dynamic>? metadata,
     PreviewData? previewData,
     String? remoteId,
@@ -95,8 +97,8 @@ class CustomMessage extends Message {
     String? uri,
   }) {
     return CustomMessage(
-      author: author,
-      createdAt: createdAt,
+      author: author ?? this.author,
+      createdAt: createdAt ?? this.createdAt,
       id: id,
       metadata: metadata == null
           ? null

--- a/lib/src/messages/file_message.dart
+++ b/lib/src/messages/file_message.dart
@@ -86,10 +86,12 @@ class FileMessage extends Message {
   /// metadata will overwite keys from the previous one.
   /// [previewData] is ignored for this message type.
   /// [remoteId], [showStatus] and [updatedAt] with null values will nullify existing value.
-  /// [status] and [uri] with null values will be overwritten by previous values.
+  /// [author], [createdAt], [status] and [uri] with null values will be overwritten by previous values.
   /// [text] is ignored for this message type.
   @override
   Message copyWith({
+    User? author,
+    int? createdAt,
     Map<String, dynamic>? metadata,
     PreviewData? previewData,
     String? remoteId,
@@ -100,8 +102,8 @@ class FileMessage extends Message {
     String? uri,
   }) {
     return FileMessage(
-      author: author,
-      createdAt: createdAt,
+      author: author ?? this.author,
+      createdAt: createdAt ?? this.createdAt,
       id: id,
       metadata: metadata == null
           ? null

--- a/lib/src/messages/image_message.dart
+++ b/lib/src/messages/image_message.dart
@@ -88,10 +88,12 @@ class ImageMessage extends Message {
   /// metadata will overwite keys from the previous one.
   /// [previewData] is ignored for this message type.
   /// [remoteId], [showStatus] and [updatedAt] with null values will nullify existing value.
-  /// [status] and [uri] with null values will be overwritten by previous values.
+  /// [author], [createdAt], [status] and [uri] with null values will be overwritten by previous values.
   /// [text] is ignored for this message type.
   @override
   Message copyWith({
+    User? author,
+    int? createdAt,
     Map<String, dynamic>? metadata,
     PreviewData? previewData,
     String? remoteId,
@@ -102,8 +104,8 @@ class ImageMessage extends Message {
     String? uri,
   }) {
     return ImageMessage(
-      author: author,
-      createdAt: createdAt,
+      author: author ?? this.author,
+      createdAt: createdAt ?? this.createdAt,
       height: height,
       id: id,
       metadata: metadata == null

--- a/lib/src/messages/text_message.dart
+++ b/lib/src/messages/text_message.dart
@@ -81,10 +81,12 @@ class TextMessage extends Message {
   /// both metadatas will be merged into one Map, where keys from a passed
   /// metadata will overwite keys from the previous one.
   /// [previewData], [remoteId], [showStatus] and [updatedAt] with null values will nullify existing value.
-  /// [status] and [text] with null values will be overwritten by previous values.
+  /// [author], [createdAt], [status] and [text] with null values will be overwritten by previous values.
   /// [uri] is ignored for this message type.
   @override
   Message copyWith({
+    User? author,
+    int? createdAt,
     Map<String, dynamic>? metadata,
     PreviewData? previewData,
     String? remoteId,
@@ -95,8 +97,8 @@ class TextMessage extends Message {
     String? uri,
   }) {
     return TextMessage(
-      author: author,
-      createdAt: createdAt,
+      author: author ?? this.author,
+      createdAt: createdAt ?? this.createdAt,
       id: id,
       metadata: metadata == null
           ? null

--- a/lib/src/messages/unsupported_message.dart
+++ b/lib/src/messages/unsupported_message.dart
@@ -55,11 +55,13 @@ class UnsupportedMessage extends Message {
   /// metadata will overwite keys from the previous one.
   /// [previewData] is ignored for this message type.
   /// [remoteId], [showStatus] and [updatedAt] with null values will nullify existing value.
-  /// [status] with null value will be overwritten by the previous status.
+  /// [author], [createdAt], [status] with null value will be overwritten by the previous status.
   /// [text] is ignored for this message type.
   /// [uri] is ignored for this message type.
   @override
   Message copyWith({
+    User? author,
+    int? createdAt,
     Map<String, dynamic>? metadata,
     PreviewData? previewData,
     String? remoteId,
@@ -70,8 +72,8 @@ class UnsupportedMessage extends Message {
     String? uri,
   }) {
     return UnsupportedMessage(
-      author: author,
-      createdAt: createdAt,
+      author: author ?? this.author,
+      createdAt: createdAt ?? this.createdAt,
       id: id,
       metadata: metadata == null
           ? null


### PR DESCRIPTION
When working with firestore and the internal cache, it is sometimes beneficial to save a message where `createdAt` is `FieldValue.serverTimestamp` but the initial version to show in the chat is `DateTime.now()`. Currently, we have to write and maintain extensions to recreate the message for this. It is obviously nicer if those are part of the main repo. In general, a `copyWith` should allow overriding all values, I feel.