### PR TITLE
Update to Flutter 3

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -24,6 +24,7 @@ linter:
   rules:
     # avoid_print: false  # Uncomment to disable the `avoid_print` rule
     # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
+    - use_super_parameters
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,14 +7,14 @@ homepage: https://flyer.chat
 repository: https://github.com/flyerhq/flutter_chat_types
 
 environment:
-  sdk: ">=2.16.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
   equatable: ^2.0.3
-  json_annotation: ^4.4.0
-  meta: ^1.7.0
+  json_annotation: ^4.5.0
+  meta: ^1.8.0
 
 dev_dependencies:
-  build_runner: ^2.1.8
-  flutter_lints: ^1.0.4
-  json_serializable: ^6.1.5
+  build_runner: ^2.1.11
+  flutter_lints: ^2.0.1
+  json_serializable: ^6.2.0


### PR DESCRIPTION
Not really many changes. If we were to change the `Message` constructor to accept named parameters (which is nicer in general), we could make use of the super parameters of Dart 2.17.