### PR TITLE
Add system message type

### DIFF
--- a/lib/src/message.dart
+++ b/lib/src/message.dart
@@ -4,12 +4,13 @@ import 'package:meta/meta.dart';
 import 'messages/custom_message.dart';
 import 'messages/file_message.dart';
 import 'messages/image_message.dart';
+import 'messages/system_message.dart';
 import 'messages/text_message.dart';
 import 'messages/unsupported_message.dart';
 import 'user.dart' show User;
 
 /// All possible message types.
-enum MessageType { custom, file, image, text, unsupported }
+enum MessageType { custom, file, image, text, system, unsupported }
 
 /// All possible statuses message can have.
 enum Status { delivered, error, seen, sending, sent }
@@ -35,18 +36,23 @@ abstract class Message extends Equatable {
   /// Creates a particular message from a map (decoded JSON).
   /// Type is determined by the `type` field.
   factory Message.fromJson(Map<String, dynamic> json) {
-    final type = json['type'] as String;
+    final type = MessageType.values.firstWhere(
+      (e) => e.name == json['type'],
+      orElse: () => MessageType.unsupported,
+    );
 
     switch (type) {
-      case 'custom':
+      case MessageType.custom:
         return CustomMessage.fromJson(json);
-      case 'file':
+      case MessageType.file:
         return FileMessage.fromJson(json);
-      case 'image':
+      case MessageType.image:
         return ImageMessage.fromJson(json);
-      case 'text':
+      case MessageType.system:
+        return SystemMessage.fromJson(json);
+      case MessageType.text:
         return TextMessage.fromJson(json);
-      default:
+      case MessageType.unsupported:
         return UnsupportedMessage.fromJson(json);
     }
   }

--- a/lib/src/messages/custom_message.g.dart
+++ b/lib/src/messages/custom_message.g.dart
@@ -60,5 +60,6 @@ const _$MessageTypeEnumMap = {
   MessageType.file: 'file',
   MessageType.image: 'image',
   MessageType.text: 'text',
+  MessageType.system: 'system',
   MessageType.unsupported: 'unsupported',
 };

--- a/lib/src/messages/file_message.g.dart
+++ b/lib/src/messages/file_message.g.dart
@@ -69,5 +69,6 @@ const _$MessageTypeEnumMap = {
   MessageType.file: 'file',
   MessageType.image: 'image',
   MessageType.text: 'text',
+  MessageType.system: 'system',
   MessageType.unsupported: 'unsupported',
 };

--- a/lib/src/messages/image_message.g.dart
+++ b/lib/src/messages/image_message.g.dart
@@ -69,5 +69,6 @@ const _$MessageTypeEnumMap = {
   MessageType.file: 'file',
   MessageType.image: 'image',
   MessageType.text: 'text',
+  MessageType.system: 'system',
   MessageType.unsupported: 'unsupported',
 };

--- a/lib/src/messages/system_message.dart
+++ b/lib/src/messages/system_message.dart
@@ -13,7 +13,7 @@ part 'system_message.g.dart';
 abstract class SystemMessage extends Message {
   /// Creates a custom message.
   const SystemMessage._({
-    required super.author,
+    super.author = const User(id: 'system'),
     super.createdAt,
     required super.id,
     super.metadata,
@@ -27,7 +27,7 @@ abstract class SystemMessage extends Message {
   }) : super(type: type ?? MessageType.system);
 
   const factory SystemMessage({
-    required User author,
+    User author,
     int? createdAt,
     required String id,
     Map<String, dynamic>? metadata,
@@ -81,7 +81,7 @@ abstract class SystemMessage extends Message {
 /// A utility class to enable better copyWith.
 class _SystemMessage extends SystemMessage {
   const _SystemMessage({
-    required super.author,
+    super.author,
     super.createdAt,
     required super.id,
     super.metadata,

--- a/lib/src/messages/system_message.dart
+++ b/lib/src/messages/system_message.dart
@@ -1,0 +1,129 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:meta/meta.dart';
+
+import '../message.dart';
+import '../user.dart' show User;
+
+part 'system_message.g.dart';
+
+/// A class that represents a system message (anything around chat management). Use [metadata] to store anything
+/// you want.
+@JsonSerializable()
+@immutable
+abstract class SystemMessage extends Message {
+  /// Creates a custom message.
+  const SystemMessage._({
+    required super.author,
+    super.createdAt,
+    required super.id,
+    super.metadata,
+    super.remoteId,
+    super.repliedMessage,
+    super.roomId,
+    super.showStatus,
+    super.status,
+    MessageType? type,
+    super.updatedAt,
+  }) : super(type: type ?? MessageType.system);
+
+  const factory SystemMessage({
+    required User author,
+    int? createdAt,
+    required String id,
+    Map<String, dynamic>? metadata,
+    String? remoteId,
+    Message? repliedMessage,
+    String? roomId,
+    bool? showStatus,
+    Status? status,
+    MessageType? type,
+    int? updatedAt,
+  }) = _SystemMessage;
+
+  /// Creates a custom message from a map (decoded JSON).
+  factory SystemMessage.fromJson(Map<String, dynamic> json) =>
+      _$SystemMessageFromJson(json);
+
+  /// Equatable props.
+  @override
+  List<Object?> get props => [
+        author,
+        createdAt,
+        id,
+        metadata,
+        remoteId,
+        repliedMessage,
+        roomId,
+        status,
+        updatedAt,
+      ];
+
+  @override
+  Message copyWith({
+    User? author,
+    int? createdAt,
+    String? id,
+    Map<String, dynamic>? metadata,
+    String? remoteId,
+    Message? repliedMessage,
+    String? roomId,
+    bool? showStatus,
+    Status? status,
+    int? updatedAt,
+  });
+
+  /// Converts a custom message to the map representation,
+  /// encodable to JSON.
+  @override
+  Map<String, dynamic> toJson() => _$SystemMessageToJson(this);
+}
+
+/// A utility class to enable better copyWith.
+class _SystemMessage extends SystemMessage {
+  const _SystemMessage({
+    required super.author,
+    super.createdAt,
+    required super.id,
+    super.metadata,
+    super.remoteId,
+    super.repliedMessage,
+    super.roomId,
+    super.showStatus,
+    super.status,
+    super.type,
+    super.updatedAt,
+  }) : super._();
+
+  @override
+  Message copyWith({
+    User? author,
+    dynamic createdAt = _Unset,
+    String? id,
+    dynamic metadata = _Unset,
+    dynamic remoteId = _Unset,
+    dynamic repliedMessage = _Unset,
+    dynamic roomId,
+    dynamic showStatus = _Unset,
+    dynamic status = _Unset,
+    dynamic updatedAt = _Unset,
+  }) =>
+      _SystemMessage(
+        author: author ?? this.author,
+        createdAt: createdAt == _Unset ? this.createdAt : createdAt as int?,
+        id: id ?? this.id,
+        metadata: metadata == _Unset
+            ? this.metadata
+            : metadata as Map<String, dynamic>?,
+        remoteId: remoteId == _Unset ? this.remoteId : remoteId as String?,
+        repliedMessage: repliedMessage == _Unset
+            ? this.repliedMessage
+            : repliedMessage as Message?,
+        roomId: roomId == _Unset ? this.roomId : roomId as String?,
+        showStatus:
+            showStatus == _Unset ? this.showStatus : showStatus as bool?,
+        status: status == _Unset ? this.status : status as Status?,
+        updatedAt: updatedAt == _Unset ? this.updatedAt : updatedAt as int?,
+      );
+}
+
+class _Unset {}

--- a/lib/src/messages/system_message.g.dart
+++ b/lib/src/messages/system_message.g.dart
@@ -1,19 +1,17 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'text_message.dart';
+part of 'system_message.dart';
 
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
-TextMessage _$TextMessageFromJson(Map<String, dynamic> json) => TextMessage(
+SystemMessage _$SystemMessageFromJson(Map<String, dynamic> json) =>
+    SystemMessage(
       author: User.fromJson(json['author'] as Map<String, dynamic>),
       createdAt: json['createdAt'] as int?,
       id: json['id'] as String,
       metadata: json['metadata'] as Map<String, dynamic>?,
-      previewData: json['previewData'] == null
-          ? null
-          : PreviewData.fromJson(json['previewData'] as Map<String, dynamic>),
       remoteId: json['remoteId'] as String?,
       repliedMessage: json['repliedMessage'] == null
           ? null
@@ -21,12 +19,11 @@ TextMessage _$TextMessageFromJson(Map<String, dynamic> json) => TextMessage(
       roomId: json['roomId'] as String?,
       showStatus: json['showStatus'] as bool?,
       status: $enumDecodeNullable(_$StatusEnumMap, json['status']),
-      text: json['text'] as String,
       type: $enumDecodeNullable(_$MessageTypeEnumMap, json['type']),
       updatedAt: json['updatedAt'] as int?,
     );
 
-Map<String, dynamic> _$TextMessageToJson(TextMessage instance) {
+Map<String, dynamic> _$SystemMessageToJson(SystemMessage instance) {
   final val = <String, dynamic>{
     'author': instance.author.toJson(),
   };
@@ -47,8 +44,6 @@ Map<String, dynamic> _$TextMessageToJson(TextMessage instance) {
   writeNotNull('status', _$StatusEnumMap[instance.status]);
   val['type'] = _$MessageTypeEnumMap[instance.type];
   writeNotNull('updatedAt', instance.updatedAt);
-  writeNotNull('previewData', instance.previewData?.toJson());
-  val['text'] = instance.text;
   return val;
 }
 

--- a/lib/src/messages/unsupported_message.g.dart
+++ b/lib/src/messages/unsupported_message.g.dart
@@ -60,5 +60,6 @@ const _$MessageTypeEnumMap = {
   MessageType.file: 'file',
   MessageType.image: 'image',
   MessageType.text: 'text',
+  MessageType.system: 'system',
   MessageType.unsupported: 'unsupported',
 };


### PR DESCRIPTION
First step to add system messages to chat.

Open questions:
- I removed the fromPartial since these messages won't be sent through user interfaces. If you want to, I can re-add it though.
- Becaues of the system message nature, should we remove the `author`, `status` and `showStatus` for these messages? What about replies (in our application people could want to reply/react to system messages too.