### PR TITLE
add audio_message

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -1,5 +1,4 @@
-import 'package:flutter_chat_types/flutter_chat_types.dart'
-    show TextMessage, User;
+import 'package:flutter_chat_types/flutter_chat_types.dart' show TextMessage, AudioMessage, PartialAudio, User;
 
 void main() {
   const user = User(id: 'authorId');
@@ -13,4 +12,53 @@ void main() {
   };
   // ignore: avoid_print
   print(TextMessage.fromJson(json).toJson());
+  _audioMessageTest();
+  _audioMessagePartialTest();
+}
+
+void _audioMessageTest() {
+  const user = User(id: 'authorId');
+  const message = AudioMessage(
+    name: 'myAudio',
+    author: user,
+    id: 'id',
+    size: 100,
+    uri: 'https://myaudio.com',
+    duration: Duration(seconds: 5),
+  );
+  // ignore: avoid_print
+  print(message.toJson());
+  final json = {
+    'author': {'id': 'authorId'},
+    'id': 'id',
+    'name': 'myAudio',
+    'uri': 'https://myaudio.com',
+    'size': 100,
+    'length': 5000000,
+  };
+  // ignore: avoid_print
+  print(AudioMessage.fromJson(json).toJson());
+}
+
+void _audioMessagePartialTest() {
+  const user = User(id: 'authorId');
+  final json = {
+    'author': {'id': 'authorId'},
+    'id': 'id',
+    'length': 5000000,
+    'uri': 'https://myaudio.com',
+    'size': 100,
+    'name': 'myAudio',
+  };
+  final partial = PartialAudio.fromJson(json);
+  final message = AudioMessage.fromPartial(
+    author: user,
+    partialAudio: partial,
+    id: 'id',
+  );
+  // ignore: avoid_print
+  print(message.toJson());
+
+  // ignore: avoid_print
+  print(AudioMessage.fromJson(json).toJson());
 }

--- a/lib/flutter_chat_types.dart
+++ b/lib/flutter_chat_types.dart
@@ -1,9 +1,11 @@
 library flutter_chat_types;
 
 export 'src/message.dart';
+export 'src/messages/audio_message.dart';
 export 'src/messages/custom_message.dart';
 export 'src/messages/file_message.dart';
 export 'src/messages/image_message.dart';
+export 'src/messages/partial_audio.dart';
 export 'src/messages/partial_custom.dart';
 export 'src/messages/partial_file.dart';
 export 'src/messages/partial_image.dart';

--- a/lib/src/message.dart
+++ b/lib/src/message.dart
@@ -1,6 +1,7 @@
 import 'package:equatable/equatable.dart';
 import 'package:meta/meta.dart';
 
+import 'messages/audio_message.dart';
 import 'messages/custom_message.dart';
 import 'messages/file_message.dart';
 import 'messages/image_message.dart';
@@ -10,7 +11,7 @@ import 'messages/unsupported_message.dart';
 import 'user.dart' show User;
 
 /// All possible message types.
-enum MessageType { custom, file, image, system, text, unsupported }
+enum MessageType { custom, file, image, system, text, audio, unsupported }
 
 /// All possible statuses message can have.
 enum Status { delivered, error, seen, sending, sent }
@@ -52,6 +53,8 @@ abstract class Message extends Equatable {
         return SystemMessage.fromJson(json);
       case MessageType.text:
         return TextMessage.fromJson(json);
+      case MessageType.audio:
+        return AudioMessage.fromJson(json);
       case MessageType.unsupported:
         return UnsupportedMessage.fromJson(json);
     }

--- a/lib/src/messages/audio_message.dart
+++ b/lib/src/messages/audio_message.dart
@@ -49,6 +49,7 @@ abstract class AudioMessage extends Message {
     required String uri,
     required Duration duration,
     String? mimeType,
+    List<double>? waveForm,
   }) = _AudioMessage;
 
   /// Creates an image message from a map (decoded JSON).

--- a/lib/src/messages/audio_message.dart
+++ b/lib/src/messages/audio_message.dart
@@ -80,7 +80,7 @@ abstract class AudioMessage extends Message {
         showStatus: showStatus,
         size: partialAudio.size,
         status: status,
-        type: MessageType.image,
+        type: MessageType.audio,
         updatedAt: updatedAt,
         uri: partialAudio.uri,
         waveForm: partialAudio.waveForm,

--- a/lib/src/messages/audio_message.dart
+++ b/lib/src/messages/audio_message.dart
@@ -1,0 +1,214 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:meta/meta.dart';
+
+import '../message.dart';
+import '../user.dart' show User;
+import 'partial_audio.dart';
+
+part 'audio_message.g.dart';
+
+/// A class that represents image message.
+@JsonSerializable()
+@immutable
+abstract class AudioMessage extends Message {
+  /// Creates an image message.
+  const AudioMessage._({
+    required super.author,
+    super.createdAt,
+    required this.duration,
+    required super.id,
+    super.metadata,
+    required this.name,
+    super.remoteId,
+    super.repliedMessage,
+    super.roomId,
+    super.showStatus,
+    required this.size,
+    super.status,
+    MessageType? type,
+    super.updatedAt,
+    required this.uri,
+    this.waveForm,
+    this.mimeType,
+  }) : super(type: type ?? MessageType.audio);
+
+  const factory AudioMessage({
+    required User author,
+    int? createdAt,
+    required String id,
+    Map<String, dynamic>? metadata,
+    required String name,
+    String? remoteId,
+    Message? repliedMessage,
+    String? roomId,
+    bool? showStatus,
+    required num size,
+    Status? status,
+    MessageType? type,
+    int? updatedAt,
+    required String uri,
+    required Duration duration,
+    String? mimeType,
+  }) = _AudioMessage;
+
+  /// Creates an image message from a map (decoded JSON).
+  factory AudioMessage.fromJson(Map<String, dynamic> json) => _$AudioMessageFromJson(json);
+
+  /// Creates a full image message from a partial one.
+  factory AudioMessage.fromPartial({
+    required User author,
+    int? createdAt,
+    required String id,
+    required PartialAudio partialAudio,
+    String? remoteId,
+    String? roomId,
+    bool? showStatus,
+    Status? status,
+    int? updatedAt,
+  }) =>
+      _AudioMessage(
+        author: author,
+        createdAt: createdAt,
+        duration: partialAudio.duration,
+        id: id,
+        metadata: partialAudio.metadata,
+        name: partialAudio.name,
+        remoteId: remoteId,
+        repliedMessage: partialAudio.repliedMessage,
+        roomId: roomId,
+        showStatus: showStatus,
+        size: partialAudio.size,
+        status: status,
+        type: MessageType.image,
+        updatedAt: updatedAt,
+        uri: partialAudio.uri,
+        waveForm: partialAudio.waveForm,
+        mimeType: partialAudio.mimeType,
+      );
+
+  /// The length of the audio.
+  final Duration duration;
+
+  /// Media type of the audio file.
+  final String? mimeType;
+
+  /// Wave form represented as a list of decibel level, each comprised between 0 and 120.
+  final List<double>? waveForm;
+
+  /// The audio file source (either a remote URL or a local resource).
+  final String uri;
+
+  /// The name of the audio.
+  final String name;
+
+  /// Size of the audio in bytes.
+  final num size;
+
+  /// Equatable props.
+  @override
+  List<Object?> get props => [
+        author,
+        createdAt,
+        mimeType,
+        id,
+        metadata,
+        name,
+        remoteId,
+        repliedMessage,
+        roomId,
+        size,
+        status,
+        updatedAt,
+        uri,
+        waveForm,
+        duration,
+      ];
+
+  @override
+  Message copyWith({
+    User? author,
+    int? createdAt,
+    double? height,
+    String? id,
+    Map<String, dynamic>? metadata,
+    String? name,
+    String? remoteId,
+    Message? repliedMessage,
+    String? roomId,
+    bool? showStatus,
+    num? size,
+    Status? status,
+    int? updatedAt,
+    String? uri,
+    double? width,
+  });
+
+  /// Converts an image message to the map representation, encodable to JSON.
+  @override
+  Map<String, dynamic> toJson() => _$AudioMessageToJson(this);
+}
+
+/// A utility class to enable better copyWith.
+class _AudioMessage extends AudioMessage {
+  const _AudioMessage({
+    required super.author,
+    super.createdAt,
+    required super.duration,
+    required super.id,
+    super.metadata,
+    required super.name,
+    super.remoteId,
+    super.repliedMessage,
+    super.roomId,
+    super.showStatus,
+    required super.size,
+    super.status,
+    super.type,
+    super.updatedAt,
+    required super.uri,
+    super.waveForm,
+    super.mimeType,
+  }) : super._();
+
+  @override
+  Message copyWith({
+    User? author,
+    dynamic createdAt = _Unset,
+    dynamic height = _Unset,
+    String? id,
+    dynamic metadata = _Unset,
+    dynamic duration = _Unset,
+    dynamic waveForm = _Unset,
+    dynamic mimeType = _Unset,
+    String? name,
+    dynamic remoteId = _Unset,
+    dynamic repliedMessage = _Unset,
+    dynamic roomId,
+    dynamic showStatus = _Unset,
+    num? size,
+    dynamic status = _Unset,
+    dynamic updatedAt = _Unset,
+    String? uri,
+    dynamic width = _Unset,
+  }) =>
+      _AudioMessage(
+        author: author ?? this.author,
+        createdAt: createdAt == _Unset ? this.createdAt : createdAt as int?,
+        duration: duration == _Unset ? this.duration : duration as Duration,
+        id: id ?? this.id,
+        metadata: metadata == _Unset ? this.metadata : metadata as Map<String, dynamic>?,
+        name: name ?? this.name,
+        remoteId: remoteId == _Unset ? this.remoteId : remoteId as String?,
+        repliedMessage: repliedMessage == _Unset ? this.repliedMessage : repliedMessage as Message?,
+        roomId: roomId == _Unset ? this.roomId : roomId as String?,
+        showStatus: showStatus == _Unset ? this.showStatus : showStatus as bool?,
+        size: size ?? this.size,
+        status: status == _Unset ? this.status : status as Status?,
+        updatedAt: updatedAt == _Unset ? this.updatedAt : updatedAt as int?,
+        uri: uri ?? this.uri,
+        waveForm: waveForm == _Unset ? this.waveForm : waveForm as List<double>?,
+        mimeType: mimeType == _Unset ? this.mimeType : mimeType as String?,
+      );
+}
+
+class _Unset {}

--- a/lib/src/messages/audio_message.g.dart
+++ b/lib/src/messages/audio_message.g.dart
@@ -25,6 +25,9 @@ AudioMessage _$AudioMessageFromJson(Map<String, dynamic> json) => AudioMessage(
       uri: json['uri'] as String,
       duration: Duration(microseconds: json['duration'] as int),
       mimeType: json['mimeType'] as String?,
+      waveForm: (json['waveForm'] as List<dynamic>?)
+          ?.map((e) => (e as num).toDouble())
+          .toList(),
     );
 
 Map<String, dynamic> _$AudioMessageToJson(AudioMessage instance) {
@@ -50,6 +53,7 @@ Map<String, dynamic> _$AudioMessageToJson(AudioMessage instance) {
   writeNotNull('updatedAt', instance.updatedAt);
   val['duration'] = instance.duration.inMicroseconds;
   writeNotNull('mimeType', instance.mimeType);
+  writeNotNull('waveForm', instance.waveForm);
   val['uri'] = instance.uri;
   val['name'] = instance.name;
   val['size'] = instance.size;

--- a/lib/src/messages/audio_message.g.dart
+++ b/lib/src/messages/audio_message.g.dart
@@ -1,32 +1,33 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'text_message.dart';
+part of 'audio_message.dart';
 
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
-TextMessage _$TextMessageFromJson(Map<String, dynamic> json) => TextMessage(
+AudioMessage _$AudioMessageFromJson(Map<String, dynamic> json) => AudioMessage(
       author: User.fromJson(json['author'] as Map<String, dynamic>),
       createdAt: json['createdAt'] as int?,
       id: json['id'] as String,
       metadata: json['metadata'] as Map<String, dynamic>?,
-      previewData: json['previewData'] == null
-          ? null
-          : PreviewData.fromJson(json['previewData'] as Map<String, dynamic>),
+      name: json['name'] as String,
       remoteId: json['remoteId'] as String?,
       repliedMessage: json['repliedMessage'] == null
           ? null
           : Message.fromJson(json['repliedMessage'] as Map<String, dynamic>),
       roomId: json['roomId'] as String?,
       showStatus: json['showStatus'] as bool?,
+      size: json['size'] as num,
       status: $enumDecodeNullable(_$StatusEnumMap, json['status']),
-      text: json['text'] as String,
       type: $enumDecodeNullable(_$MessageTypeEnumMap, json['type']),
       updatedAt: json['updatedAt'] as int?,
+      uri: json['uri'] as String,
+      duration: Duration(microseconds: json['duration'] as int),
+      mimeType: json['mimeType'] as String?,
     );
 
-Map<String, dynamic> _$TextMessageToJson(TextMessage instance) {
+Map<String, dynamic> _$AudioMessageToJson(AudioMessage instance) {
   final val = <String, dynamic>{
     'author': instance.author.toJson(),
   };
@@ -47,8 +48,11 @@ Map<String, dynamic> _$TextMessageToJson(TextMessage instance) {
   writeNotNull('status', _$StatusEnumMap[instance.status]);
   val['type'] = _$MessageTypeEnumMap[instance.type]!;
   writeNotNull('updatedAt', instance.updatedAt);
-  writeNotNull('previewData', instance.previewData?.toJson());
-  val['text'] = instance.text;
+  val['duration'] = instance.duration.inMicroseconds;
+  writeNotNull('mimeType', instance.mimeType);
+  val['uri'] = instance.uri;
+  val['name'] = instance.name;
+  val['size'] = instance.size;
   return val;
 }
 

--- a/lib/src/messages/custom_message.g.dart
+++ b/lib/src/messages/custom_message.g.dart
@@ -61,5 +61,6 @@ const _$MessageTypeEnumMap = {
   MessageType.image: 'image',
   MessageType.system: 'system',
   MessageType.text: 'text',
+  MessageType.audio: 'audio',
   MessageType.unsupported: 'unsupported',
 };

--- a/lib/src/messages/file_message.g.dart
+++ b/lib/src/messages/file_message.g.dart
@@ -70,5 +70,6 @@ const _$MessageTypeEnumMap = {
   MessageType.image: 'image',
   MessageType.system: 'system',
   MessageType.text: 'text',
+  MessageType.audio: 'audio',
   MessageType.unsupported: 'unsupported',
 };

--- a/lib/src/messages/image_message.g.dart
+++ b/lib/src/messages/image_message.g.dart
@@ -70,5 +70,6 @@ const _$MessageTypeEnumMap = {
   MessageType.image: 'image',
   MessageType.system: 'system',
   MessageType.text: 'text',
+  MessageType.audio: 'audio',
   MessageType.unsupported: 'unsupported',
 };

--- a/lib/src/messages/partial_audio.dart
+++ b/lib/src/messages/partial_audio.dart
@@ -1,0 +1,56 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:meta/meta.dart';
+
+import '../message.dart';
+
+part 'partial_audio.g.dart';
+
+/// A class that represents partial image message.
+@JsonSerializable()
+@immutable
+class PartialAudio {
+  /// Creates a partial image message with all variables image can have.
+  /// Use [ImageMessage] to create a full message.
+  /// You can use [ImageMessage.fromPartial] constructor to create a full
+  /// message from a partial one.
+  const PartialAudio({
+    required this.duration,
+    this.metadata,
+    required this.name,
+    this.repliedMessage,
+    required this.size,
+    required this.uri,
+    this.waveForm,
+    this.mimeType,
+  });
+
+  /// Creates a partial image message from a map (decoded JSON).
+  factory PartialAudio.fromJson(Map<String, dynamic> json) => _$PartialAudioFromJson(json);
+
+  /// The length of the audio.
+  final Duration duration;
+
+  /// Media type of the audio file.
+  final String? mimeType;
+
+  /// Wave form represented as a list of decibel level, each comprised between 0 and 120.
+  final List<double>? waveForm;
+
+  /// The audio file source (either a remote URL or a local resource).
+  final String uri;
+
+  /// The name of the audio.
+  final String name;
+
+  /// Size of the audio in bytes.
+  final num size;
+
+  /// Additional custom metadata or attributes related to the message.
+  final Map<String, dynamic>? metadata;
+
+  /// Message that is being replied to with the current message.
+  final Message? repliedMessage;
+
+  /// Converts a partial image message to the map representation, encodable to JSON.
+  Map<String, dynamic> toJson() => _$PartialAudioToJson(this);
+}

--- a/lib/src/messages/partial_audio.g.dart
+++ b/lib/src/messages/partial_audio.g.dart
@@ -1,0 +1,43 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'partial_audio.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+PartialAudio _$PartialAudioFromJson(Map<String, dynamic> json) => PartialAudio(
+      duration: Duration(microseconds: json['duration'] as int),
+      metadata: json['metadata'] as Map<String, dynamic>?,
+      name: json['name'] as String,
+      repliedMessage: json['repliedMessage'] == null
+          ? null
+          : Message.fromJson(json['repliedMessage'] as Map<String, dynamic>),
+      size: json['size'] as num,
+      uri: json['uri'] as String,
+      waveForm: (json['waveForm'] as List<dynamic>?)
+          ?.map((e) => (e as num).toDouble())
+          .toList(),
+      mimeType: json['mimeType'] as String?,
+    );
+
+Map<String, dynamic> _$PartialAudioToJson(PartialAudio instance) {
+  final val = <String, dynamic>{
+    'duration': instance.duration.inMicroseconds,
+  };
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('mimeType', instance.mimeType);
+  writeNotNull('waveForm', instance.waveForm);
+  val['uri'] = instance.uri;
+  val['name'] = instance.name;
+  val['size'] = instance.size;
+  writeNotNull('metadata', instance.metadata);
+  writeNotNull('repliedMessage', instance.repliedMessage?.toJson());
+  return val;
+}

--- a/lib/src/messages/system_message.g.dart
+++ b/lib/src/messages/system_message.g.dart
@@ -63,5 +63,6 @@ const _$MessageTypeEnumMap = {
   MessageType.image: 'image',
   MessageType.system: 'system',
   MessageType.text: 'text',
+  MessageType.audio: 'audio',
   MessageType.unsupported: 'unsupported',
 };

--- a/lib/src/messages/unsupported_message.g.dart
+++ b/lib/src/messages/unsupported_message.g.dart
@@ -61,5 +61,6 @@ const _$MessageTypeEnumMap = {
   MessageType.image: 'image',
   MessageType.system: 'system',
   MessageType.text: 'text',
+  MessageType.audio: 'audio',
   MessageType.unsupported: 'unsupported',
 };


### PR DESCRIPTION
introduce a new type which supports all information required for persistence of an audio message. This data are independent of any audio player and implementation in the flutter_chat_ui